### PR TITLE
Add type title CSS part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,3 +511,9 @@
 * [ci skip] automated merge master->stage. syncing main branches [1db411a](https://github.com/advanced-rest-client/api-type-documentation/commit/1db411acf22d1c59c69d91f39d9ba40f6acf1d62) by Ci agent
 
 
+
+<a name="4.1.2"></a>
+
+### Features
+
+* Fixes [#27](https://github.com/advanced-rest-client/api-documentation/issues/27) - Add CSS part to the title element.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-documentation",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-documentation",
   "description": "A documentation module for RAML types (resources) using AMF data model",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiTypeDocumentationElement.js
+++ b/src/ApiTypeDocumentationElement.js
@@ -221,7 +221,7 @@ export class ApiTypeDocumentationElement extends AmfHelperMixin(LitElement) {
       headerLevel
     } = this;
     return html `<style>${this.styles}</style>
-    ${typeTitle ? html`<div class="title" role="heading" aria-level="${headerLevel}">${typeTitle}</div>` : ''}
+    ${typeTitle ? html`<div class="title" role="heading" aria-level="${headerLevel}" part="type-title">${typeTitle}</div>` : ''}
     ${hasCustomProperties ?
       html`<api-annotation-document .amf="${amf}" .shape="${type}"></api-annotation-document>` : ''}
 

--- a/test/api-type-documentation.test.js
+++ b/test/api-type-documentation.test.js
@@ -184,6 +184,11 @@ describe('ApiTypeDocumentationElement', () => {
         it('api-type-document renders with renderReadOnly set to true', async () => {
           assert.isTrue(element.shadowRoot.querySelector('api-type-document').renderReadOnly)
         });
+
+        it('renders the type title', async () => {
+          const node = element.shadowRoot.querySelector('.title');
+          assert.dom.equal(node, `<div aria-level="2" class="title" part="type-title" role="heading">EnurableType</div>`);
+        });
       });
 
       describe(`Schema object - ${  item[0]}`, () => {


### PR DESCRIPTION
Fixes [#27](https://github.com/advanced-rest-client/api-documentation/issues/27)

- Add CSS part to type title